### PR TITLE
Add an option to base64-encode SVG files too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ resolver.url('page/background.jpg')
 ```
 
 ### `.data(path)`
-Returns a base64-encoded content of an asset. SVG files would be non-encoded, because then [they benefit in size](http://css-tricks.com/probably-dont-base64-svg/) (use the `forceBase64` option to override this behaviour).
+Returns a base64-encoded content of an asset. SVG files would be non-encoded, because then [they benefit in size](http://css-tricks.com/probably-dont-base64-svg/) (use the [`forceBase64`](#forcebase64) option to override this behaviour).
 
 ```js
 var resolver = new Assets();
@@ -156,8 +156,7 @@ var resolver = new Assets({
 Defaults to `false`.
 
 ### `forceBase64`
-
-Force the `data` method to encode _all_ assets using base64, including SVG files.
+Forces [`data(path)`](#datapath) to encode all assets using base64 - _including_ SVG files.
 
 Defaults to `false`.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ resolver.url('page/background.jpg')
 ```
 
 ### `.data(path)`
-Returns a base64-encoded content of an asset. SVG files would be non-encoded, because then [they benefit in size](http://css-tricks.com/probably-dont-base64-svg/).
+Returns a base64-encoded content of an asset. SVG files would be non-encoded, because then [they benefit in size](http://css-tricks.com/probably-dont-base64-svg/) (use the `forceBase64` option to override this behaviour).
 
 ```js
 var resolver = new Assets();
@@ -152,6 +152,12 @@ var resolver = new Assets({
   }
 });
 ```
+
+Defaults to `false`.
+
+### `forceBase64`
+
+Force the `data` method to encode _all_ assets using base64, including SVG files.
 
 Defaults to `false`.
 

--- a/lib/__utils__/encodeBuffer.js
+++ b/lib/__utils__/encodeBuffer.js
@@ -1,5 +1,5 @@
-module.exports = function (buffer, mediaType) {
-  if (mediaType === 'image/svg+xml') {
+module.exports = function (buffer, mediaType, options) {
+  if (mediaType === 'image/svg+xml' && !options.forceBase64) {
     return 'charset=utf-8,' + encodeURIComponent(buffer.toString('utf8').trim());
   }
   return 'base64,' + buffer.toString('base64');

--- a/lib/data.js
+++ b/lib/data.js
@@ -20,6 +20,7 @@ module.exports = function (to, options, callback) {
 
   options = extend({
     basePath: '.',
+    forceBase64: false,
     loadPaths: []
   }, options);
 
@@ -32,7 +33,7 @@ module.exports = function (to, options, callback) {
       var mediaType = mime.lookup(resolvedPath);
       return preadFile(resolvedPath)
         .then(function (buffer) {
-          var content = encodeBuffer(buffer, mediaType);
+          var content = encodeBuffer(buffer, mediaType, options);
           return 'data:' + mediaType + ';' + content + (toUrl.hash || '');
         });
     })


### PR DESCRIPTION
Allow users to force even SVGs to be base64-encoded - this option can be passed through transparently in packages like `postcss-assets`.

This is useful/required for web developers who need to support IE11.
