### PR TITLE
Use imagemin to minify the inlined images

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ For example: `"assets/css"`.
 
 Defaults to `false`.
 
+### `imagemin`
+Minify the inlined image by [imagemin](https://www.npmjs.com/package/imagemin), option value will transfer to [options of imagemin.buffer](https://www.npmjs.com/package/imagemin#options-1).
+
+For example:
+
+```
+{
+  plugins: [
+    require('imagemin-jpegtran')({
+      progressive: true,
+      arithmetic: true,
+    }),
+  ],
+}
+```
+
+Defaults to `null`
+
 Path resolution
 ---------------
 

--- a/lib/data.js
+++ b/lib/data.js
@@ -5,7 +5,14 @@ var mime = require('mime');
 var Promise = require('bluebird');
 var resolvePath = require('./path');
 var url = require('url');
-var imagemin = require('imagemin');
+var imagemin = (function (r) {
+  try {
+    return r('imagemin');
+  } catch (e) {
+    return null;
+  }
+}(require));
+
 
 var preadFile = Promise.promisify(fs.readFile);
 
@@ -33,7 +40,7 @@ module.exports = function (to, options, callback) {
       var mediaType = mime.lookup(resolvedPath);
       return preadFile(resolvedPath)
         .then(function (buffer) {
-          if (options.imagemin == null) return buffer;
+          if (options.imagemin == null || imagemin == null) return buffer;
           return imagemin.buffer(buffer, options.imagemin);
         })
         .then(function (buffer) {

--- a/lib/data.js
+++ b/lib/data.js
@@ -5,6 +5,7 @@ var mime = require('mime');
 var Promise = require('bluebird');
 var resolvePath = require('./path');
 var url = require('url');
+var imagemin = require('imagemin');
 
 var preadFile = Promise.promisify(fs.readFile);
 
@@ -31,6 +32,10 @@ module.exports = function (to, options, callback) {
     .then(function (resolvedPath) {
       var mediaType = mime.lookup(resolvedPath);
       return preadFile(resolvedPath)
+        .then(function (buffer) {
+          if (options.imagemin == null) return buffer;
+          return imagemin.buffer(buffer, options.imagemin);
+        })
         .then(function (buffer) {
           var content = encodeBuffer(buffer, mediaType);
           return 'data:' + mediaType + ';' + content + (toUrl.hash || '');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "calipers-svg": "^2.0.0",
     "calipers-webp": "^2.0.0",
     "glob": "^7.0.6",
+    "imagemin": "^5.3.1",
     "lodash": "^4.15.0",
     "mime": "^1.3.4"
   },
@@ -38,6 +39,7 @@
     "eslint": "^2.13.1",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.7.0",
+    "imagemin-jpegtran": "^5.0.2",
     "nyc": "^8.3.0",
     "sinon": "^1.17.5"
   },

--- a/test/data.js
+++ b/test/data.js
@@ -2,7 +2,13 @@ import test from 'ava';
 
 import resolveData from '../lib/data';
 
-import imageminJpegtran from 'imagemin-jpegtran';
+const imageminJpegtran = (function (r) {
+  try {
+    return r('imagemin-jpegtran');
+  } catch (e) {
+    return null;
+  }
+}(require));
 
 test('w/o options', t =>
   resolveData('fixtures/duplicate-1.jpg')
@@ -70,17 +76,19 @@ test.cb('node-style callback + non-existing file', (t) => {
   });
 });
 
-test('minified inline', t =>
-  resolveData('fixtures/duplicate-1.jpg', {
-    imagemin: {
-      plugins: [
-        imageminJpegtran({
-          progressive: true,
-          arithmetic: true,
-        }),
-      ],
-    },
-  }).then((minifiedDataUrl) => resolveData('fixtures/duplicate-1.jpg')
-    .then((originDataUrl) => {
-      t.true(minifiedDataUrl.length < originDataUrl.length);
-    }), t.fail));
+if (imageminJpegtran != null) {
+  test('minified inline', t =>
+    resolveData('fixtures/duplicate-1.jpg', {
+      imagemin: {
+        plugins: [
+          imageminJpegtran({
+            progressive: true,
+            arithmetic: true,
+          }),
+        ],
+      },
+    }).then((minifiedDataUrl) => resolveData('fixtures/duplicate-1.jpg')
+      .then((originDataUrl) => {
+        t.true(minifiedDataUrl.length < originDataUrl.length);
+      }), t.fail));
+}

--- a/test/data.js
+++ b/test/data.js
@@ -2,6 +2,8 @@ import test from 'ava';
 
 import resolveData from '../lib/data';
 
+import imageminJpegtran from 'imagemin-jpegtran';
+
 test('w/o options', t =>
   resolveData('fixtures/duplicate-1.jpg')
     .then((resolvedDataUrl) => {
@@ -67,3 +69,18 @@ test.cb('node-style callback + non-existing file', (t) => {
     t.end();
   });
 });
+
+test('minified inline', t =>
+  resolveData('fixtures/duplicate-1.jpg', {
+    imagemin: {
+      plugins: [
+        imageminJpegtran({
+          progressive: true,
+          arithmetic: true,
+        }),
+      ],
+    },
+  }).then((minifiedDataUrl) => resolveData('fixtures/duplicate-1.jpg')
+    .then((originDataUrl) => {
+      t.true(minifiedDataUrl.length < originDataUrl.length);
+    }), t.fail));


### PR DESCRIPTION
### `imagemin`
Minify the inlined image by [imagemin](https://www.npmjs.com/package/imagemin), option value will transfer to [options of imagemin.buffer](https://www.npmjs.com/package/imagemin#options-1).

For example:

```
imagemin: {
  plugins: [
    require('imagemin-jpegtran')({
      progressive: true,
      arithmetic: true,
    }),
  ],
}
```

Defaults to `null`
