### PR TITLE
Compatibility with Yarn PNP for Calipers

### DIFF
--- a/lib/size.js
+++ b/lib/size.js
@@ -1,4 +1,10 @@
-var calipers = require('calipers')('webp', 'png', 'jpeg', 'gif', 'svg');
+var calipers = require('calipers')(
+  require('calipers-webp'),
+  require('calipers-png'),
+  require('calipers-jpeg'),
+  require('calipers-gif'),
+  require('calipers-svg')
+);
 var Promise = require('bluebird');
 var resolvePath = require('./path');
 


### PR DESCRIPTION
As Yarn PNP needs files to be loaded from where their dependencies are configured. We can't use Calipers' way of loading plugins transitively.

This change allows Assets and Calipers to work fine with Yarn PNP